### PR TITLE
Add tests for Obsidian plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build plugin using esbuild
         run: npm run build
 
+      - name: Run tests using Jest
+        run: npm test
+
       - name: Run Semantic Release to bump version and create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -168,6 +168,29 @@ Alternatively, manually test using your preferred REST client at the base URL:
 ```
 http://localhost:27124/api
 ```
+
+### Running Tests with Jest
+
+To run the automated tests using Jest, follow these steps:
+
+1. **Install Dependencies:**
+
+   If you haven't already, install the necessary dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. **Run Tests:**
+
+   Execute the test script:
+
+   ```bash
+   npm test
+   ```
+
+This will run all the test cases defined in the `tests` directory and provide you with a summary of the test results.
+
 ---
 
 ## Build and Deployment

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "node esbuild.config.mjs",
-    "build": "node esbuild.config.mjs production"
+    "build": "node esbuild.config.mjs production",
+    "test": "jest"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^13.0.1",
@@ -17,6 +18,8 @@
     "@types/node": "^20.8.1",
     "esbuild": "^0.25.0",
     "obsidian": "latest",
-    "typescript": "^4.7.0"
+    "typescript": "^4.7.0",
+    "jest": "^29.0.0",
+    "@types/jest": "^29.0.0"
   }
 }

--- a/tests/apiServer.test.ts
+++ b/tests/apiServer.test.ts
@@ -1,0 +1,128 @@
+import { Vault, TFile } from "obsidian";
+import { createServer, IncomingMessage, ServerResponse } from "http";
+import { APIBridgeServer } from "../src/apiServer";
+import { APIBridgeSettings } from "../src/main";
+
+describe("APIBridgeServer", () => {
+  let vault: Vault;
+  let settings: APIBridgeSettings;
+  let server: APIBridgeServer;
+
+  beforeEach(() => {
+    vault = {
+      getFiles: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      read: jest.fn(),
+      create: jest.fn(),
+      modify: jest.fn(),
+    } as unknown as Vault;
+
+    settings = {
+      port: 27124,
+      authToken: "my-secret-token",
+    };
+
+    server = new APIBridgeServer(vault, settings);
+  });
+
+  afterEach(() => {
+    server.shutdown();
+  });
+
+  test("should start and shutdown the server", () => {
+    server.start();
+    expect(server["server"]).not.toBeNull();
+    server.shutdown();
+    expect(server["server"]).toBeNull();
+  });
+
+  test("should handle unauthorized request", (done) => {
+    const req = {
+      headers: { "x-api-token": "wrong-token" },
+      method: "GET",
+      url: "/api/notes",
+    } as IncomingMessage;
+
+    const res = {
+      writeHead: jest.fn(),
+      end: jest.fn(() => {
+        expect(res.writeHead).toHaveBeenCalledWith(401, { "Content-Type": "application/json" });
+        expect(res.end).toHaveBeenCalledWith(JSON.stringify({ error: "Unauthorized" }));
+        done();
+      }),
+    } as unknown as ServerResponse;
+
+    server["handleRequest"](req, res);
+  });
+
+  test("should list notes", (done) => {
+    const req = {
+      headers: { "x-api-token": settings.authToken },
+      method: "GET",
+      url: "/api/notes",
+    } as IncomingMessage;
+
+    const res = {
+      writeHead: jest.fn(),
+      end: jest.fn(() => {
+        expect(res.writeHead).toHaveBeenCalledWith(200, { "Content-Type": "application/json" });
+        expect(res.end).toHaveBeenCalledWith(JSON.stringify({ files: [] }));
+        done();
+      }),
+    } as unknown as ServerResponse;
+
+    (vault.getFiles as jest.Mock).mockReturnValue([]);
+    server["handleRequest"](req, res);
+  });
+
+  test("should read a note", (done) => {
+    const req = {
+      headers: { "x-api-token": settings.authToken },
+      method: "GET",
+      url: "/api/notes/test-note",
+    } as IncomingMessage;
+
+    const res = {
+      writeHead: jest.fn(),
+      end: jest.fn(() => {
+        expect(res.writeHead).toHaveBeenCalledWith(200, { "Content-Type": "application/json" });
+        expect(res.end).toHaveBeenCalledWith(JSON.stringify({ content: "Note content" }));
+        done();
+      }),
+    } as unknown as ServerResponse;
+
+    const file = { path: "test-note" } as TFile;
+    (vault.getAbstractFileByPath as jest.Mock).mockReturnValue(file);
+    (vault.read as jest.Mock).mockResolvedValue("Note content");
+    server["handleRequest"](req, res);
+  });
+
+  test("should write a note", (done) => {
+    const req = {
+      headers: { "x-api-token": settings.authToken },
+      method: "POST",
+      url: "/api/notes/test-note",
+      on: jest.fn((event, callback) => {
+        if (event === "data") {
+          callback(JSON.stringify({ content: "New content" }));
+        }
+        if (event === "end") {
+          callback();
+        }
+      }),
+    } as unknown as IncomingMessage;
+
+    const res = {
+      writeHead: jest.fn(),
+      end: jest.fn(() => {
+        expect(res.writeHead).toHaveBeenCalledWith(200, { "Content-Type": "application/json" });
+        expect(res.end).toHaveBeenCalledWith(JSON.stringify({ message: "File written successfully." }));
+        done();
+      }),
+    } as unknown as ServerResponse;
+
+    const file = { path: "test-note" } as TFile;
+    (vault.getAbstractFileByPath as jest.Mock).mockReturnValue(file);
+    server["handleRequest"](req, res);
+  });
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,0 +1,55 @@
+import { App, PluginManifest } from "obsidian";
+import APIBridgePlugin, { APIBridgeSettings } from "../src/main";
+import { APIBridgeServer } from "../src/apiServer";
+
+describe("APIBridgePlugin", () => {
+  let app: App;
+  let manifest: PluginManifest;
+  let plugin: APIBridgePlugin;
+
+  beforeEach(async () => {
+    app = new App();
+    manifest = {
+      id: "obsidian-api-bridge",
+      name: "Obsidian API Bridge",
+      version: "0.0.1",
+      minAppVersion: "0.0.1",
+      description: "A secure local API server plugin that exposes endpoints for reading, writing, and editing your Obsidian notes.",
+      author: "Henri Wenlin",
+      authorUrl: "https://github.com/Wenlin88",
+      isDesktopOnly: true,
+    } as PluginManifest;
+
+    plugin = new APIBridgePlugin(app, manifest);
+    await plugin.onload();
+  });
+
+  afterEach(async () => {
+    await plugin.onunload();
+  });
+
+  test("should load settings", async () => {
+    const defaultSettings: APIBridgeSettings = {
+      port: 27124,
+      authToken: "my-secret-token",
+    };
+    expect(plugin.settings).toEqual(defaultSettings);
+  });
+
+  test("should start and shutdown the API server", () => {
+    const apiServer = plugin["apiServer"] as APIBridgeServer;
+    expect(apiServer).not.toBeNull();
+    expect(apiServer["server"]).not.toBeNull();
+
+    plugin.onunload();
+    expect(apiServer["server"]).toBeNull();
+  });
+
+  test("should reload the API server", async () => {
+    const apiServer = plugin["apiServer"] as APIBridgeServer;
+    const originalServerInstance = apiServer["server"];
+
+    await plugin.reloadServer();
+    expect(apiServer["server"]).not.toBe(originalServerInstance);
+  });
+});


### PR DESCRIPTION
Add tests for the Obsidian plugin using Jest.

* **package.json**:
  - Add Jest as a dev dependency.
  - Add a test script to run Jest.

* **tests/apiServer.test.ts**:
  - Import necessary modules and dependencies.
  - Write unit tests for `APIBridgeServer` class.

* **tests/main.test.ts**:
  - Import necessary modules and dependencies.
  - Write unit tests for `APIBridgePlugin` class.

* **.github/workflows/ci.yml**:
  - Add a step to run tests using Jest.

* **README.md**:
  - Add instructions for running tests using Jest.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Wenlin88/Obsidian-API-Gateway/pull/2?shareId=a629101b-6a98-481c-9164-d0366570d0dc).